### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag vpnbeast/encryption-service:${{ env.release_version }}
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: vpnbeast/encryption-service
           tags: "latest,${{ env.release_version }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore